### PR TITLE
Point to general IDE Support page, rather than IDEA

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@ title: Gauge
             </div>
             <div class="block-grid-item">
                 <div class="homepage-icon link">
-                    <a href="http://getgauge.io/documentation/user/current/ide_support/intellij_idea.html">
+                    <a href="http://getgauge.io/documentation/user/current/ide_support/README.html">
                         <i class="fa fa-support fa-3x"></i>
                         <h5>IDE support</h5>
                     </a>


### PR DESCRIPTION
Gauge supports three IDEs. We should point to a page that shows all of them, rather than just Intellij IDEA.
