### PR TITLE
Change "Fork on Github" spacing to match home page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,7 +22,7 @@
 <body>
 
     <a href="//github.com/getgauge/gauge" class="fork-ribbon">
-        <span class="fa fa-code-fork"></span>Fork on Github</a>
+        <span class="fa fa-code-fork"></span> Fork on Github</a>
 
     <div class="inner-banner">
         <div class="container">


### PR DESCRIPTION
The hope page has a space between the fork icon and the words "Fork on GitHub". Other pages, such as Download, do not. This can be a bit distracting when going back and forth between the pages. I think it looks better with the space, so I'm proposing this change as a fix. It may be minor, but it eliminates a distraction.
