### PR TITLE
Fix broken examples link

### DIFF
--- a/contribute/index.html
+++ b/contribute/index.html
@@ -151,7 +151,7 @@
                 </figure>
                 <p>
                   We maintain a set of
-                  <a href='https://github.com/getgauge/gauge-examples' target='_blank'>examples</a>
+                  <a href='http://getgauge.io/documentation/user/current/examples/' target='_blank'>examples</a>
                   that evolve as we add new features and languages. This is to help someone new to Gauge get started easily. If you’ve tried something you think would be useful to the community, please add it.
                 </p>
               </li>


### PR DESCRIPTION
The link to the examples in http://getgauge.io/contribute/index.html was broken. This PR fixes it and points it to http://getgauge.io/documentation/user/current/examples/ instead.
