### PR TITLE
Fix broken examples link in redesign branch

### DIFF
--- a/source/contribute.html.haml
+++ b/source/contribute.html.haml
@@ -49,7 +49,7 @@ credit_link: https://www.flickr.com/photos/turinboy/5217595026
             = image_tag "svg/contribution/icon_contribute_examples.svg", {:title => "Enhance our Examples", :alt => "Enhance our Examples"}           
           %p
             We maintain a set of
-            %a{:href => "https://github.com/getgauge/gauge-examples", :target => "_blank"} examples
+            %a{:href => "http://getgauge.io/documentation/user/current/examples/", :target => "_blank"} examples
             that evolve as we add new features and languages. This is to help someone new to Gauge get started easily. If you’ve tried something you think would be useful to the community, please add it.
       
         %li.tile


### PR DESCRIPTION
The same change as #17, but in the `redesign` branch this time.
