### PR TITLE
Remove contribute from the main menu and get started areas.

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -17,7 +17,7 @@ set :layouts_dir, 'layouts'
 
 set :haml, { ugly: true }
 
-redirect 'download/index.html', to: '../get-started/index.html'
+redirect 'download/index.html', to: '../get-started.html'
 
 helpers do
 	def is_home_page()

--- a/source/assets/stylesheets/scss/_general.scss
+++ b/source/assets/stylesheets/scss/_general.scss
@@ -306,15 +306,3 @@ pre {
         padding: 8px 15px;
     }
 }
-
-/**
- * Blog
- */
-.draft-post {
-    padding: 1rem;
-    text-align: center;
-    background-color: rgb(245, 193, 14);
-    color: rgba(51, 51, 51, 0.95);
-    font-weight: bold;
-    font-size: 2rem;
-}

--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -12,8 +12,7 @@ credit_link: https://www.flickr.com/photos/acmoraes/8629549600/
       %span.subquote
         Simple. Collaborative. Adaptable.
     .actions
-      %a.btn.btn-primary{:href => "get-started/index.html"} Get Started
-      %a.btn.btn-default{:href => "contribute/index.html"} Contribute
+      %a.btn.btn-primary{:href => "get-started.html"} Get Started
     
     .features.qas
       %h2.question

--- a/source/layouts/layout.html.haml
+++ b/source/layouts/layout.html.haml
@@ -48,14 +48,9 @@ title: Gauge | ThoughtWorks
                 %li
                   = nav_bar_link 'Plugins', 'plugins.html', :class => "link-plugins"
             %li.dropdown
-              = nav_bar_link 'Contribute', 'contribute.html', :class => "toplink-contribute"
-              %ul.level1
-                %li
-                  = nav_bar_link 'Contribute', 'contribute.html', :class => "link-contribute"
-                %li
-                  = nav_bar_link 'CLA', 'cla.html', :class => "link-cla"
-            %li.dropdown
-              = link_to 'Documentation', 'https://docs.getgauge.io', :class => "link-documentation"
+              = link_to 'Documentation', '//docs.getgauge.io', :class => "link-documentation"
+            %li
+              = link_to 'Blog', '//blog.getgauge.io', :class => "link-blog"
 
         %button.navbtn.menu.collapse
           %span
@@ -73,7 +68,7 @@ title: Gauge | ThoughtWorks
                 %i.icon.join-us
                 Join Us
             %li
-              %a.contribute{:href => "https://gitter.im/getgauge/chat", :target => "_blank"}
+              %a.chat{:href => "https://gitter.im/getgauge/chat", :target => "_blank"}
                 %i.icon.develop-with-us
                 Talk to Us
             %li


### PR DESCRIPTION
Reduce clutter by removing contribute from the menu as it's been added to the footer.